### PR TITLE
API versioning, added rage invalidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,11 @@
 /.cproject
 /.settings
 /.vs
-
+/.vscode
+/.ccls-cache
 /setup.sh
 
 /BUILD
+/build
 /out
 

--- a/include/ocx/ocx.h
+++ b/include/ocx/ocx.h
@@ -162,7 +162,7 @@ namespace ocx {
         class core : public v20201012::core 
         {
         public:
-            virtual void invalidate_page_ptrs(u64 page_paddr_start, u64 size) = 0;
+            virtual void invalidate_page_ptrs(u64 start, u64 end) = 0;
         };
 
         class env : public v20201012::env {};

--- a/include/ocx/ocx.h
+++ b/include/ocx/ocx.h
@@ -13,7 +13,9 @@
 #include <stdint.h>
 #include <memory>
 
-#define OCX_API_VERSION 20201012ull
+#define OCX_API_VERSION_20201012 20201012ull
+#define OCX_API_VERSION_20220601 20220601ull
+#define OCX_API_VERSION OCX_API_VERSION_20220601
 
 #ifdef _MSC_VER
 #  ifdef OCX_STATIC
@@ -66,91 +68,109 @@ namespace ocx {
         HINT_SEVL,
     };
 
-    class env
-    {
-    public:
-        virtual ~env() {}
+    namespace v20201012 {
 
-        virtual u8* get_page_ptr_r(u64 page_paddr) = 0;
-        virtual u8* get_page_ptr_w(u64 page_paddr) = 0;
+        class env
+        {
+        public:
+            virtual ~env() {}
 
-        virtual void protect_page(u8* page_ptr, u64 page_addr) = 0;
+            virtual u8* get_page_ptr_r(u64 page_paddr) = 0;
+            virtual u8* get_page_ptr_w(u64 page_paddr) = 0;
 
-        virtual response transport(const transaction& tx) = 0;
-        virtual void signal(u64 sigid, bool set) = 0;
+            virtual void protect_page(u8* page_ptr, u64 page_addr) = 0;
 
-        virtual void broadcast_syscall(int callno, std::shared_ptr<void> arg,
-                                       bool async) = 0;
+            virtual response transport(const transaction& tx) = 0;
+            virtual void signal(u64 sigid, bool set) = 0;
 
-        virtual u64 get_time_ps() = 0;
-        virtual const char* get_param(const char* name) = 0;
+            virtual void broadcast_syscall(int callno, std::shared_ptr<void> arg,
+                                        bool async) = 0;
 
-        virtual void notify(u64 eventid, u64 time_ps) = 0;
-        virtual void cancel(u64 eventid) = 0;
+            virtual u64 get_time_ps() = 0;
+            virtual const char* get_param(const char* name) = 0;
 
-        virtual void hint(hint_kind kind) = 0;
+            virtual void notify(u64 eventid, u64 time_ps) = 0;
+            virtual void cancel(u64 eventid) = 0;
 
-        virtual void handle_begin_basic_block(u64 vaddr) = 0;
-        virtual bool handle_breakpoint(u64 vaddr) = 0;
-        virtual bool handle_watchpoint(u64 vaddr, u64 size, u64 data,
-                                       bool iswr) = 0;
+            virtual void hint(hint_kind kind) = 0;
+
+            virtual void handle_begin_basic_block(u64 vaddr) = 0;
+            virtual bool handle_breakpoint(u64 vaddr) = 0;
+            virtual bool handle_watchpoint(u64 vaddr, u64 size, u64 data,
+                                        bool iswr) = 0;
+        };
+
+        class core
+        {
+        protected:
+            virtual ~core() {}
+
+        public:
+            virtual const char* provider() = 0;
+
+            virtual const char* arch() = 0;
+            virtual const char* arch_gdb() = 0;
+            virtual const char* arch_family() = 0;
+
+            virtual u64 page_size() = 0;
+
+            virtual void set_id(u64 procid, u64 coreid) = 0;
+
+            virtual u64 step(u64 num_insn) = 0;
+            virtual void stop() = 0;
+            virtual u64 insn_count() = 0;
+
+            virtual void reset() = 0;
+            virtual void interrupt(u64 irq, bool set) = 0;
+
+            virtual void notified(u64 eventid) = 0;
+
+            virtual u64 pc_regid() = 0;
+            virtual u64 sp_regid() = 0;
+            virtual u64 num_regs() = 0;
+
+            virtual size_t      reg_size(u64 regid) = 0;
+            virtual const char* reg_name(u64 regid) = 0;
+
+            virtual bool read_reg(u64 regid, void* buf) = 0;
+            virtual bool write_reg(u64 regid, const void* buf) = 0;
+
+            virtual bool add_breakpoint(u64 vaddr) = 0;
+            virtual bool remove_breakpoint(u64 vaddr) = 0;
+
+            virtual bool add_watchpoint(u64 vaddr, u64 size, bool iswr) = 0;
+            virtual bool remove_watchpoint(u64 vaddr, u64 size, bool iswr) = 0;
+
+            virtual bool trace_basic_blocks(bool on) = 0;
+
+            virtual bool virt_to_phys(u64 vaddr, u64& paddr) = 0;
+
+            virtual void handle_syscall(int callno, std::shared_ptr<void> arg) = 0;
+
+            virtual u64 disassemble(u64 addr, char* tgt, size_t tgtsz) = 0;
+
+            virtual void invalidate_page_ptrs() = 0;
+            virtual void invalidate_page_ptr(u64 page_paddr) = 0;
+
+            virtual void tb_flush() = 0;
+            virtual void tb_flush_page(u64 start, u64 end) = 0;
+        };
     };
 
-    class core
-    {
-    protected:
-        virtual ~core() {}
+    namespace v20220601 {
 
-    public:
-        virtual const char* provider() = 0;
+        class core : public v20201012::core 
+        {
+        public:
+            virtual void invalidate_page_ptrs(u64 page_paddr_start, u64 size) = 0;
+        };
 
-        virtual const char* arch() = 0;
-        virtual const char* arch_gdb() = 0;
-        virtual const char* arch_family() = 0;
+        class env : public v20201012::env {};
 
-        virtual u64 page_size() = 0;
+    }
 
-        virtual void set_id(u64 procid, u64 coreid) = 0;
-
-        virtual u64 step(u64 num_insn) = 0;
-        virtual void stop() = 0;
-        virtual u64 insn_count() = 0;
-
-        virtual void reset() = 0;
-        virtual void interrupt(u64 irq, bool set) = 0;
-
-        virtual void notified(u64 eventid) = 0;
-
-        virtual u64 pc_regid() = 0;
-        virtual u64 sp_regid() = 0;
-        virtual u64 num_regs() = 0;
-
-        virtual size_t      reg_size(u64 regid) = 0;
-        virtual const char* reg_name(u64 regid) = 0;
-
-        virtual bool read_reg(u64 regid, void* buf) = 0;
-        virtual bool write_reg(u64 regid, const void* buf) = 0;
-
-        virtual bool add_breakpoint(u64 vaddr) = 0;
-        virtual bool remove_breakpoint(u64 vaddr) = 0;
-
-        virtual bool add_watchpoint(u64 vaddr, u64 size, bool iswr) = 0;
-        virtual bool remove_watchpoint(u64 vaddr, u64 size, bool iswr) = 0;
-
-        virtual bool trace_basic_blocks(bool on) = 0;
-
-        virtual bool virt_to_phys(u64 vaddr, u64& paddr) = 0;
-
-        virtual void handle_syscall(int callno, std::shared_ptr<void> arg) = 0;
-
-        virtual u64 disassemble(u64 addr, char* tgt, size_t tgtsz) = 0;
-
-        virtual void invalidate_page_ptrs() = 0;
-        virtual void invalidate_page_ptr(u64 page_paddr) = 0;
-
-        virtual void tb_flush() = 0;
-        virtual void tb_flush_page(u64 start, u64 end) = 0;
-    };
+    class core : public v20220601::core {};
+    class env : public v20220601::env {};
 
     extern OCX_API core* create_instance(u64 ver, env& e, const char* variant);
     extern OCX_API void  delete_instance(core* c);

--- a/include/ocx/ocx.h
+++ b/include/ocx/ocx.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (C) 2019 Synopsys, Inc.
+* Copyright (C) 2019-2022 Synopsys, Inc.
 * This source code is licensed under the terms of the GNU General Public License
 * as published by the Free Software Foundation; either version 2 of the License
 * or (at your option) any later version.
@@ -13,9 +13,7 @@
 #include <stdint.h>
 #include <memory>
 
-#define OCX_API_VERSION_20201012 20201012ull
-#define OCX_API_VERSION_20220601 20220601ull
-#define OCX_API_VERSION OCX_API_VERSION_20220601
+#define OCX_API_VERSION 20201012ull
 
 #ifdef _MSC_VER
 #  ifdef OCX_STATIC
@@ -68,109 +66,97 @@ namespace ocx {
         HINT_SEVL,
     };
 
-    namespace v20201012 {
+    class env
+    {
+    public:
+        virtual ~env() {}
 
-        class env
-        {
-        public:
-            virtual ~env() {}
+        virtual u8* get_page_ptr_r(u64 page_paddr) = 0;
+        virtual u8* get_page_ptr_w(u64 page_paddr) = 0;
 
-            virtual u8* get_page_ptr_r(u64 page_paddr) = 0;
-            virtual u8* get_page_ptr_w(u64 page_paddr) = 0;
+        virtual void protect_page(u8* page_ptr, u64 page_addr) = 0;
 
-            virtual void protect_page(u8* page_ptr, u64 page_addr) = 0;
+        virtual response transport(const transaction& tx) = 0;
+        virtual void signal(u64 sigid, bool set) = 0;
 
-            virtual response transport(const transaction& tx) = 0;
-            virtual void signal(u64 sigid, bool set) = 0;
+        virtual void broadcast_syscall(int callno, std::shared_ptr<void> arg,
+                                    bool async) = 0;
 
-            virtual void broadcast_syscall(int callno, std::shared_ptr<void> arg,
-                                        bool async) = 0;
+        virtual u64 get_time_ps() = 0;
+        virtual const char* get_param(const char* name) = 0;
 
-            virtual u64 get_time_ps() = 0;
-            virtual const char* get_param(const char* name) = 0;
+        virtual void notify(u64 eventid, u64 time_ps) = 0;
+        virtual void cancel(u64 eventid) = 0;
 
-            virtual void notify(u64 eventid, u64 time_ps) = 0;
-            virtual void cancel(u64 eventid) = 0;
+        virtual void hint(hint_kind kind) = 0;
 
-            virtual void hint(hint_kind kind) = 0;
-
-            virtual void handle_begin_basic_block(u64 vaddr) = 0;
-            virtual bool handle_breakpoint(u64 vaddr) = 0;
-            virtual bool handle_watchpoint(u64 vaddr, u64 size, u64 data,
-                                        bool iswr) = 0;
-        };
-
-        class core
-        {
-        protected:
-            virtual ~core() {}
-
-        public:
-            virtual const char* provider() = 0;
-
-            virtual const char* arch() = 0;
-            virtual const char* arch_gdb() = 0;
-            virtual const char* arch_family() = 0;
-
-            virtual u64 page_size() = 0;
-
-            virtual void set_id(u64 procid, u64 coreid) = 0;
-
-            virtual u64 step(u64 num_insn) = 0;
-            virtual void stop() = 0;
-            virtual u64 insn_count() = 0;
-
-            virtual void reset() = 0;
-            virtual void interrupt(u64 irq, bool set) = 0;
-
-            virtual void notified(u64 eventid) = 0;
-
-            virtual u64 pc_regid() = 0;
-            virtual u64 sp_regid() = 0;
-            virtual u64 num_regs() = 0;
-
-            virtual size_t      reg_size(u64 regid) = 0;
-            virtual const char* reg_name(u64 regid) = 0;
-
-            virtual bool read_reg(u64 regid, void* buf) = 0;
-            virtual bool write_reg(u64 regid, const void* buf) = 0;
-
-            virtual bool add_breakpoint(u64 vaddr) = 0;
-            virtual bool remove_breakpoint(u64 vaddr) = 0;
-
-            virtual bool add_watchpoint(u64 vaddr, u64 size, bool iswr) = 0;
-            virtual bool remove_watchpoint(u64 vaddr, u64 size, bool iswr) = 0;
-
-            virtual bool trace_basic_blocks(bool on) = 0;
-
-            virtual bool virt_to_phys(u64 vaddr, u64& paddr) = 0;
-
-            virtual void handle_syscall(int callno, std::shared_ptr<void> arg) = 0;
-
-            virtual u64 disassemble(u64 addr, char* tgt, size_t tgtsz) = 0;
-
-            virtual void invalidate_page_ptrs() = 0;
-            virtual void invalidate_page_ptr(u64 page_paddr) = 0;
-
-            virtual void tb_flush() = 0;
-            virtual void tb_flush_page(u64 start, u64 end) = 0;
-        };
+        virtual void handle_begin_basic_block(u64 vaddr) = 0;
+        virtual bool handle_breakpoint(u64 vaddr) = 0;
+        virtual bool handle_watchpoint(u64 vaddr, u64 size, u64 data,
+                                    bool iswr) = 0;
     };
 
-    namespace v20220601 {
+    class core
+    {
+    protected:
+        virtual ~core() {}
 
-        class core : public v20201012::core 
-        {
-        public:
-            virtual void invalidate_page_ptrs(u64 start, u64 end) = 0;
-        };
+    public:
+        virtual const char* provider() = 0;
 
-        class env : public v20201012::env {};
+        virtual const char* arch() = 0;
+        virtual const char* arch_gdb() = 0;
+        virtual const char* arch_family() = 0;
 
-    }
+        virtual u64 page_size() = 0;
 
-    class core : public v20220601::core {};
-    class env : public v20220601::env {};
+        virtual void set_id(u64 procid, u64 coreid) = 0;
+
+        virtual u64 step(u64 num_insn) = 0;
+        virtual void stop() = 0;
+        virtual u64 insn_count() = 0;
+
+        virtual void reset() = 0;
+        virtual void interrupt(u64 irq, bool set) = 0;
+
+        virtual void notified(u64 eventid) = 0;
+
+        virtual u64 pc_regid() = 0;
+        virtual u64 sp_regid() = 0;
+        virtual u64 num_regs() = 0;
+
+        virtual size_t      reg_size(u64 regid) = 0;
+        virtual const char* reg_name(u64 regid) = 0;
+
+        virtual bool read_reg(u64 regid, void* buf) = 0;
+        virtual bool write_reg(u64 regid, const void* buf) = 0;
+
+        virtual bool add_breakpoint(u64 vaddr) = 0;
+        virtual bool remove_breakpoint(u64 vaddr) = 0;
+
+        virtual bool add_watchpoint(u64 vaddr, u64 size, bool iswr) = 0;
+        virtual bool remove_watchpoint(u64 vaddr, u64 size, bool iswr) = 0;
+
+        virtual bool trace_basic_blocks(bool on) = 0;
+
+        virtual bool virt_to_phys(u64 vaddr, u64& paddr) = 0;
+
+        virtual void handle_syscall(int callno, std::shared_ptr<void> arg) = 0;
+
+        virtual u64 disassemble(u64 addr, char* tgt, size_t tgtsz) = 0;
+
+        virtual void invalidate_page_ptrs() = 0;
+        virtual void invalidate_page_ptr(u64 page_paddr) = 0;
+
+        virtual void tb_flush() = 0;
+        virtual void tb_flush_page(u64 start, u64 end) = 0;
+    };
+
+    class core_inv_range_extension
+    {
+    public:
+        virtual void invalidate_page_ptrs(u64 start, u64 end) = 0;
+    };
 
     extern OCX_API core* create_instance(u64 ver, env& e, const char* variant);
     extern OCX_API void  delete_instance(core* c);

--- a/include/ocx/ocx.h
+++ b/include/ocx/ocx.h
@@ -80,7 +80,7 @@ namespace ocx {
         virtual void signal(u64 sigid, bool set) = 0;
 
         virtual void broadcast_syscall(int callno, std::shared_ptr<void> arg,
-                                    bool async) = 0;
+                                       bool async) = 0;
 
         virtual u64 get_time_ps() = 0;
         virtual const char* get_param(const char* name) = 0;
@@ -93,7 +93,7 @@ namespace ocx {
         virtual void handle_begin_basic_block(u64 vaddr) = 0;
         virtual bool handle_breakpoint(u64 vaddr) = 0;
         virtual bool handle_watchpoint(u64 vaddr, u64 size, u64 data,
-                                    bool iswr) = 0;
+                                       bool iswr) = 0;
     };
 
     class core

--- a/src/dummy-core.cpp
+++ b/src/dummy-core.cpp
@@ -167,9 +167,9 @@ namespace ocx {
             (void)page_paddr;
         }
 
-        virtual void invalidate_page_ptrs(u64 page_paddr_start, u64 size) override {
-            (void)page_paddr_start;
-            (void)size;
+        virtual void invalidate_page_ptrs(u64 start, u64 end) override {
+            (void)start;
+            (void)end;
         }
 
         virtual void tb_flush() override {

--- a/src/dummy-core.cpp
+++ b/src/dummy-core.cpp
@@ -167,6 +167,11 @@ namespace ocx {
             (void)page_paddr;
         }
 
+        virtual void invalidate_page_ptrs(u64 page_paddr_start, u64 size) override {
+            (void)page_paddr_start;
+            (void)size;
+        }
+
         virtual void tb_flush() override {
             return;
         }
@@ -193,10 +198,10 @@ namespace ocx {
             warned = true;
         }
 
-        if (api_version != OCX_API_VERSION)
-            return nullptr;
-
-        return new dummycore();
+        if (api_version == OCX_API_VERSION_20201012 ||
+            api_version == OCX_API_VERSION)
+            return new dummycore();
+        else return nullptr;
     }
 
     void delete_instance(core* cpu) {

--- a/src/dummy-core.cpp
+++ b/src/dummy-core.cpp
@@ -198,9 +198,10 @@ namespace ocx {
             warned = true;
         }
 
-        if (api_version == OCX_API_VERSION)
-            return new dummycore();
-        else return nullptr;
+        if (api_version != OCX_API_VERSION)
+            return nullptr;
+
+        return new dummycore();
     }
 
     void delete_instance(core* cpu) {

--- a/src/dummy-core.cpp
+++ b/src/dummy-core.cpp
@@ -14,7 +14,7 @@
 
 namespace ocx {
 
-    class dummycore: public core
+    class dummycore: public core, public core_inv_range_extension
     {
     public:
         dummycore():
@@ -198,8 +198,7 @@ namespace ocx {
             warned = true;
         }
 
-        if (api_version == OCX_API_VERSION_20201012 ||
-            api_version == OCX_API_VERSION)
+        if (api_version == OCX_API_VERSION)
             return new dummycore();
         else return nullptr;
     }

--- a/src/test-runner.cpp
+++ b/src/test-runner.cpp
@@ -161,6 +161,14 @@ TEST(ocx_basic, mismatched_version) {
         << "library returned core instance despite API version mismatch";
 }
 
+TEST(ocx_basic, older_version) {
+    corelib cl(LIBRARY_PATH);
+    mock_env env;
+    ocx::core* c = cl.create_core(env, CORE_VARIANT, OCX_API_VERSION_20201012);
+    ASSERT_NE(c, nullptr)
+        << "library returned no core instance for API version OCX_API_VERSION_20201012";
+}
+
 class ocx_core : public ::testing::Test
 {
 private:

--- a/src/test-runner.cpp
+++ b/src/test-runner.cpp
@@ -161,12 +161,17 @@ TEST(ocx_basic, mismatched_version) {
         << "library returned core instance despite API version mismatch";
 }
 
-TEST(ocx_basic, older_version) {
+TEST(ocx_basic, core_inv_range_extension) {
     corelib cl(LIBRARY_PATH);
     mock_env env;
-    ocx::core* c = cl.create_core(env, CORE_VARIANT, OCX_API_VERSION_20201012);
+    ocx::core* c = cl.create_core(env, CORE_VARIANT);
     ASSERT_NE(c, nullptr)
-        << "library returned no core instance for API version OCX_API_VERSION_20201012";
+        << "failed to create core";
+
+    auto ext = dynamic_cast<ocx::core_inv_range_extension*>(c);
+    if (ext)
+        ext->invalidate_page_ptrs(0, 0xfff);
+    cl.delete_core(c);
 }
 
 class ocx_core : public ::testing::Test


### PR DESCRIPTION
The API was missing a way to invalidate large DMI ranges with a single call. This has now been added.

Also, we have added a mechanism for versioning the API so that simulation environment and processor model do not have to agree on the exact version but can be backwards compatible (on either end).